### PR TITLE
Fix a syntax error in Canvas2d.js

### DIFF
--- a/Canvas2d.js
+++ b/Canvas2d.js
@@ -15,7 +15,7 @@ strokeStyleFunc = function() {
 			returnString += 'ctx.createRadialGradient('+ra([rint(ra(INT_NUMS)),floatValue()])+','+ra([rint(ra(INT_NUMS)),floatValue()])+','+ra([rint(ra(INT_NUMS)),floatValue()])+','+ra([rint(ra(INT_NUMS)),floatValue()])+','+ra([rint(ra(INT_NUMS)),floatValue()])+','+ra([rint(ra(INT_NUMS)),floatValue()])+')'
 			break;
 		case 2:
-			returnString += 'ctx.createPattern(img,"'+ra(['repeat','repeat-x','repeat-y','no-repeat',''])+'")'
+			returnString += 'ctx.createPattern(img,\''+ra(['repeat','repeat-x','repeat-y','no-repeat',''])+'\')'
 			break;
 	}
 	return returnString


### PR DESCRIPTION
The fuzzing file Canvas2d.js contained a syntax error relating to quotes that cause Edge to throw a Javascript error and stop execution of any Javascript on the page. 

This causes a problem because fuzzing is halted until Wadi restarts Edge, and then the problem repeats. It cuts down useful fuzzing time because when this bug is active, no fuzzing is going on.

I just changed the double quotes to single quotes and the problem was fixed.